### PR TITLE
Added domain objects and validations for opts/args, flattened options…

### DIFF
--- a/cmta/src/main/scala/cmt/CliCommands.scala
+++ b/cmta/src/main/scala/cmt/CliCommands.scala
@@ -1,0 +1,13 @@
+package cmt
+
+sealed trait CliCommand
+
+trait HasConfiguration[T]:
+  extension (t: T) def toConfig: CMTaConfig
+
+object HasConfiguration:
+
+  given HasConfiguration[Studentify] with
+    extension (studentify: Studentify)
+      def toConfig: CMTaConfig =
+        new CMTaConfig(studentify.mainRepositoryDirectory.value, studentify.maybeConfigurationFile.map(_.value))

--- a/cmta/src/main/scala/cmt/CmdLineParse.scala
+++ b/cmta/src/main/scala/cmt/CmdLineParse.scala
@@ -6,14 +6,14 @@ object CmdLineParse:
 
   final case class CmdLineParseError(errors: List[OEffect])
 
-  def parse(args: Array[String]): Either[CmdLineParseError, CmtaOptions] =
-    OParser.runParser(cmtaParser, args, CmtaOptions()) match {
+  def parse(args: Array[String]): Either[CmdLineParseError, CmtaCommands] =
+    OParser.runParser(cmtaParser, args, Missing) match {
       case (result, effects) => handleParsingResult(result, effects)
     }
 
   private def handleParsingResult(
-      maybeResult: Option[CmtaOptions],
-      effects: List[OEffect]): Either[CmdLineParseError, CmtaOptions] =
+      maybeResult: Option[CmtaCommands],
+      effects: List[OEffect]): Either[CmdLineParseError, CmtaCommands] =
     maybeResult match {
       case Some(validOptions) => Right(validOptions)
       case _                  => Left(CmdLineParseError(effects))

--- a/cmta/src/main/scala/cmt/Domain.scala
+++ b/cmta/src/main/scala/cmt/Domain.scala
@@ -1,0 +1,26 @@
+package cmt
+
+import sbt.io.syntax.File
+import sbt.io.syntax.file
+
+object domain {
+
+  final case class MainRepositoryDirectory(value: File)
+  object MainRepositoryDirectory:
+    def default(): MainRepositoryDirectory =
+      MainRepositoryDirectory(file("."))
+
+  final case class ConfigurationFile(value: File)
+  final case class StudentifiedDirectory(value: File)
+  final case class ExerciseNumber(value: Int)
+  final case class LinearizeBaseDirectory(value: File)
+  final case class RenumberFrom(value: Int)
+  final case class RenumberTo(value: Int)
+  final case class RenumberStep(value: Int)
+
+  enum DeleteExistingDirectoryDecision:
+    case DeleteExistingDirectory, DoNotDeleteExistingDirectory
+
+  enum InitializeAsGitRepositoryDecision:
+    case InitializeAsGitRepository, DoNotInitializeAsGitRepository
+}

--- a/cmta/src/main/scala/cmt/FileLike.scala
+++ b/cmta/src/main/scala/cmt/FileLike.scala
@@ -1,0 +1,42 @@
+package cmt
+
+import cmt.domain.{ConfigurationFile, LinearizeBaseDirectory, MainRepositoryDirectory, StudentifiedDirectory}
+
+trait FileLike[T]:
+  extension (t: T)
+    def exists: Boolean
+    def isFile: Boolean
+    def isDirectory: Boolean
+    def getPath: String
+
+object FileLike {
+  def apply[T](using fl: FileLike[T]) = fl
+
+  given FileLike[MainRepositoryDirectory] with
+    extension (directory: MainRepositoryDirectory)
+      def exists: Boolean = directory.value.exists
+      def isFile: Boolean = directory.value.isFile
+      def isDirectory: Boolean = directory.value.isDirectory
+      def getPath: String = directory.value.getPath
+
+  given FileLike[StudentifiedDirectory] with
+    extension (directory: StudentifiedDirectory)
+      def exists: Boolean = directory.value.exists
+      def isFile: Boolean = directory.value.isFile
+      def isDirectory: Boolean = directory.value.isDirectory
+      def getPath: String = directory.value.getPath
+
+  given FileLike[ConfigurationFile] with
+    extension (file: ConfigurationFile)
+      def exists: Boolean = file.value.exists
+      def isFile: Boolean = file.value.isFile
+      def isDirectory: Boolean = file.value.isDirectory
+      def getPath: String = file.value.getPath
+
+  given FileLike[LinearizeBaseDirectory] with
+    extension (directory: LinearizeBaseDirectory)
+      def exists: Boolean = directory.value.exists
+      def isFile: Boolean = directory.value.isFile
+      def isDirectory: Boolean = directory.value.isDirectory
+      def getPath: String = directory.value.getPath
+}

--- a/cmta/src/main/scala/cmt/Readers.scala
+++ b/cmta/src/main/scala/cmt/Readers.scala
@@ -1,0 +1,31 @@
+package cmt
+
+import cmt.domain.{ConfigurationFile, ExerciseNumber, LinearizeBaseDirectory, MainRepositoryDirectory, RenumberFrom, RenumberStep, RenumberTo, StudentifiedDirectory}
+import sbt.io.syntax.file
+
+object Readers:
+
+  implicit val mainRepositoryDirectoryReader: scopt.Read[MainRepositoryDirectory] =
+    scopt.Read.reads(path => MainRepositoryDirectory(file(path)))
+
+  implicit val configFileReader: scopt.Read[ConfigurationFile] =
+    scopt.Read.reads(path => ConfigurationFile(file(path)))
+
+  implicit val studentifiedDirectoryReader: scopt.Read[StudentifiedDirectory] =
+    scopt.Read.reads(path => StudentifiedDirectory(file(path)))
+
+  implicit val exerciseNumberReader: scopt.Read[ExerciseNumber] =
+    scopt.Read.reads(num => ExerciseNumber(num.toInt))
+
+  implicit val linearizeBaseFolderReader: scopt.Read[LinearizeBaseDirectory] =
+    scopt.Read.reads(path => LinearizeBaseDirectory(file(path)))
+
+  implicit val renumberFromReader: scopt.Read[RenumberFrom] =
+    scopt.Read.reads(num => RenumberFrom(num.toInt))
+
+  implicit val renumberToReader: scopt.Read[RenumberTo] =
+    scopt.Read.reads(num => RenumberTo(num.toInt))
+
+  implicit val renumberStepReader: scopt.Read[RenumberStep] =
+    scopt.Read.reads(num => RenumberStep(num.toInt))
+

--- a/cmta/src/main/scala/cmt/Validatable.scala
+++ b/cmta/src/main/scala/cmt/Validatable.scala
@@ -1,0 +1,54 @@
+package cmt
+
+import cmt.FileLike.given
+import cmt.Validations.*
+import cmt.domain.*
+
+trait Validatable[T]:
+  extension (t: T) def validate: Either[String, Unit]
+
+object Validatable:
+
+  given Validatable[MainRepositoryDirectory] with
+    extension (directory: MainRepositoryDirectory)
+      def validate: Either[String, Unit] =
+        for {
+          _ <- existsAndIsADirectory(directory)
+          _ <- isAGitRepository(directory.value)
+        } yield ()
+
+  given Validatable[StudentifiedDirectory] with
+    extension (directory: StudentifiedDirectory)
+      def validate: Either[String, Unit] =
+        existsAndIsADirectory(directory)
+
+  given Validatable[ConfigurationFile] with
+    extension (directory: ConfigurationFile)
+      def validate: Either[String, Unit] =
+        existsAndIsAFile(directory)
+
+  given Validatable[LinearizeBaseDirectory] with
+    extension (directory: LinearizeBaseDirectory)
+      def validate: Either[String, Unit] =
+        existsAndIsADirectory(directory)
+
+  given Validatable[RenumberFrom] with
+    extension (renumberFrom: RenumberFrom)
+      def validate: Either[String, Unit] =
+        greaterThanOrEqualToZero(renumberFrom.value)
+
+  given Validatable[RenumberTo] with
+    extension (renumberTo: RenumberTo)
+      def validate: Either[String, Unit] =
+        greaterThanOrEqualToOne(renumberTo.value)
+
+  given Validatable[RenumberStep] with
+    extension (renumberStep: RenumberStep)
+      def validate: Either[String, Unit] =
+        greaterThanOrEqualToOne(renumberStep.value)
+
+  given Validatable[Studentify] with
+    extension (studentify: Studentify)
+      def validate: Either[String, Unit] = {
+        Right(())
+      }

--- a/cmta/src/main/scala/cmt/Validations.scala
+++ b/cmta/src/main/scala/cmt/Validations.scala
@@ -1,0 +1,47 @@
+package cmt
+
+import sbt.io.syntax.File
+
+object Validations:
+
+  def exists[T](maybeExists: T)(using x: FileLike[T]): Either[String, Unit] =
+    maybeExists.exists match
+      case true  => Right(())
+      case false => Left(s"${maybeExists.getPath} does not exist")
+
+  def isADirectory[T](maybeDirectory: T)(using x: FileLike[T]): Either[String, Unit] =
+    maybeDirectory.isDirectory match
+      case true  => Right(())
+      case false => Left(s"${maybeDirectory.getPath} is not a directory")
+
+  def isAFile[T](maybeFile: T)(using x: FileLike[T]): Either[String, Unit] =
+    maybeFile.isFile match
+      case true  => Right(())
+      case false => Left(s"${maybeFile.getPath} is not a file")
+
+  def isAGitRepository(directory: File): Either[String, Unit] =
+    Helpers.resolveMainRepoPath(directory) match
+      case Right(_) => Right(())
+      case Left(_)  => Left(s"${directory.getPath} is not a git repository")
+
+  def existsAndIsADirectory[T](maybe: T)(using x: FileLike[T]): Either[String, Unit] =
+    for {
+      _ <- exists(maybe)
+      _ <- isADirectory(maybe)
+    } yield ()
+
+  def existsAndIsAFile[T](maybe: T)(using x: FileLike[T]): Either[String, Unit] =
+    for {
+      _ <- exists(maybe)
+      _ <- isAFile(maybe)
+    } yield ()
+
+  def greaterThanOrEqualToZero(num: Int): Either[String, Unit] =
+    greaterThanOrEqualTo(num, target = 0)
+
+  def greaterThanOrEqualToOne(num: Int): Either[String, Unit] =
+    greaterThanOrEqualTo(num, target = 1)
+
+  def greaterThanOrEqualTo(num: Int, target: Int): Either[String, Unit] =
+    if num >= 0 then Right(())
+    else Left(s"number should be >= $target")

--- a/cmta/src/test/scala/cmt/CommandLineParseTest.scala
+++ b/cmta/src/test/scala/cmt/CommandLineParseTest.scala
@@ -1,5 +1,6 @@
 package cmt
 
+import cmt.domain.{MainRepositoryDirectory, StudentifiedDirectory}
 import org.scalatest.BeforeAndAfterAll
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpecLike
@@ -69,12 +70,11 @@ class CommandLineParseTest extends AnyWordSpecLike with Matchers with BeforeAndA
         val resultOr = CmdLineParse.parse(args)
 
         val result = assertRight(resultOr)
-        val expectedResult = CmtaOptions(
-          Helpers.resolveMainRepoPath(file(mainRepositoryPath)).toOption.get,
-          Studentify(
-            Some(file(studentifiedDirectoryPath)),
-            forceDeleteExistingDestinationFolder = false,
-            initializeAsGitRepo = false))
+        val expectedResult = Studentify
+          .default()
+          .copy(
+            mainRepositoryDirectory = MainRepositoryDirectory(Helpers.resolveMainRepoPath(file(mainRepositoryPath)).toOption.get),
+            maybeStudentifiedDirectory = Some(StudentifiedDirectory(file(studentifiedDirectoryPath))))
 
         result shouldBe expectedResult
       }


### PR DESCRIPTION
There are a few changes squashed into one PR, here. As they're kind-of-related I thought it worth providing a single, big, PR to demonstrate and the we can split, if necessary.

1. Added custom types for `domain` objects collected from cli options/arguments: specific types of files, flags, etc.
2. Added type classes for validating those domain objects
3. Flattened the cli options type to just use the commands - removing the `CmtaOptions` type altogether.

This last one (3) is the most contentious, here. The trade-off is that, while the `throwOrAction` blocks are simpler and much easier to parse by humans, the options types themselves become more complex.

I've added `ValidCommand` as a sub-trait of `CmtaCommands` which allows us to:

1. Easily `match` on valid/invalid commands received from the parser
2. Provide a `validate` method (not included in this PR) on the `ValidCommands` themselves. This will allow us to do things like check that the `mainRepositoryDirectory` and `studentifiedDirectory` provided on the cli aren't the same directory - this would be difficult to do with the previous, nested, structure.

So the complexity from parsing has passed to the types themselves, but that _should_ mean that things are easier to implement later on and adding a new command is also easier as the whole contract for a command is provided by `ValidCommand`...

Let me know what you like and what you don't.