### PR TITLE
Test coverage #2

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -6,6 +6,6 @@ lazy val `course-management-tools` =
 
 lazy val core = project.in(file("core")).settings(CommonSettings.commonSettings: _*)
 
-lazy val cmta = project.in(file("cmta")).dependsOn(core).settings(CommonSettings.commonSettings: _*)
+lazy val cmta = project.in(file("cmta")).dependsOn(core, core % "test->test").settings(CommonSettings.commonSettings: _*)
 
-lazy val cmtc = project.in(file("cmtc")).dependsOn(core).settings(CommonSettings.commonSettings: _*)
+lazy val cmtc = project.in(file("cmtc")).dependsOn(core, core % "test->test").settings(CommonSettings.commonSettings: _*)

--- a/cmta/src/main/scala/cmt/CMTmain.scala
+++ b/cmta/src/main/scala/cmt/CMTmain.scala
@@ -9,7 +9,7 @@ object Main:
       case Right(options) =>
         selectAndExecuteCommand(options)
 
-      case Left(CmdLineParse.CmdLineParseError(x)) =>
+      case Left(CmdLineParseError(x)) =>
         printError(x.collect { case ReportError(msg) => msg }.mkString("\n"))
     }
 

--- a/cmta/src/main/scala/cmt/CmdLineParse.scala
+++ b/cmta/src/main/scala/cmt/CmdLineParse.scala
@@ -1,20 +1,6 @@
 package cmt
 
-import scopt.{OEffect, OParser}
-
-object CmdLineParse:
-
-  final case class CmdLineParseError(errors: List[OEffect])
+object CmdLineParse extends CliParser:
 
   def parse(args: Array[String]): Either[CmdLineParseError, CmtaOptions] =
-    OParser.runParser(cmtaParser, args, CmtaOptions()) match {
-      case (result, effects) => handleParsingResult(result, effects)
-    }
-
-  private def handleParsingResult(
-      maybeResult: Option[CmtaOptions],
-      effects: List[OEffect]): Either[CmdLineParseError, CmtaOptions] =
-    maybeResult match {
-      case Some(validOptions) => Right(validOptions)
-      case _                  => Left(CmdLineParseError(effects))
-    }
+    _parse(cmtaParser, CmtaOptions())(args)

--- a/cmta/src/test/scala/cmt/CommandLineParseTest.scala
+++ b/cmta/src/test/scala/cmt/CommandLineParseTest.scala
@@ -1,79 +1,12 @@
 package cmt
 
-import org.scalatest.BeforeAndAfterAll
-import org.scalatest.matchers.should.Matchers
-import org.scalatest.prop.TableFor2
-import org.scalatest.wordspec.AnyWordSpecLike
-import org.scalatestplus.scalacheck.ScalaCheckPropertyChecks
-import sbt.io.IO
-import sbt.io.syntax.*
-import scopt.OEffect.ReportError
+import cmt.support.CommandLineParseTestBase
 
-import scala.language.postfixOps
-
-trait CommandLineArguments {
-  val identifier: String
-  def invalidArguments(tempDirectory: File): TableFor2[Seq[String], Seq[ReportError]]
-  def validArguments(tempDirectory: File): TableFor2[Seq[String], CmtaOptions]
-}
-
-class CommandLineParseTest extends AnyWordSpecLike with Matchers with BeforeAndAfterAll with ScalaCheckPropertyChecks {
-
-  private val tempDirectory = IO.createTemporaryDirectory
-
-  override def afterAll(): Unit =
-    tempDirectory.delete()
-
-  private val commandArguments = List(StudentifyArguments, DuplicateInsertBeforeArguments, LinearizeArguments, DelinearizeArguments, RenumberArguments)
-
-  "CLI Parser" when {
-
-    commandArguments.foreach { command =>
-
-      s"given invalid ${command.identifier} arguments" should {
-
-        "report appropriate errors" in {
-          forAll(command.invalidArguments(tempDirectory)) { (args: Seq[String], errors: Seq[ReportError]) =>
-            assertFailureWithErrors(args.toArray, errors *)
-          }
-        }
-      }
-    }
-
-    commandArguments.foreach { command =>
-
-      s"given valid ${command.identifier} arguments" should {
-
-        "return expected results" in {
-          forAll(command.validArguments(tempDirectory)) { (args: Seq[String], expectedResult: CmtaOptions) =>
-            assertSuccessWithResponse(args.toArray, expectedResult)
-          }
-        }
-      }
-    }
-  }
-
-  private def assertFailureWithErrors(args: Array[String], errors: ReportError*) = {
-    val resultOr = CmdLineParse.parse(args)
-    val error = assertLeft(resultOr)
-    (error.errors should contain).allElementsOf(errors)
-  }
-
-  private def assertSuccessWithResponse(args: Array[String], expectedResult: CmtaOptions) = {
-    val resultOr = CmdLineParse.parse(args)
-    val result = assertRight(resultOr)
-    result shouldBe expectedResult
-  }
-
-  private def assertRight[E, T](either: Either[E, T]): T =
-    either match {
-      case Left(error)   => throw new IllegalStateException(s"Expected Either.right, got Either.left [$error]")
-      case Right(result) => result
-    }
-
-  private def assertLeft[E, T](either: Either[E, T]): E =
-    either match {
-      case Left(error)   => error
-      case Right(result) => throw new IllegalStateException(s"Expected Either.left, got Either.right [$result]")
-    }
-}
+class CommandLineParseTest
+    extends CommandLineParseTestBase[CmtaOptions](
+      CmdLineParse.parse,
+      StudentifyArguments,
+      DuplicateInsertBeforeArguments,
+      LinearizeArguments,
+      DelinearizeArguments,
+      RenumberArguments)

--- a/cmta/src/test/scala/cmt/DelinearizeArguments.scala
+++ b/cmta/src/test/scala/cmt/DelinearizeArguments.scala
@@ -1,6 +1,7 @@
 package cmt
 
 import cmt.TestDirectories.{firstRealDirectory, nonExistentDirectory, realFile, secondRealDirectory}
+import cmt.support.CommandLineArguments
 import org.scalatest.BeforeAndAfterAll
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.prop.Tables
@@ -9,7 +10,7 @@ import sbt.io.IO
 import sbt.io.syntax.{File, file}
 import scopt.OEffect.ReportError
 
-object DelinearizeArguments extends CommandLineArguments with Tables {
+object DelinearizeArguments extends CommandLineArguments[CmtaOptions] with Tables {
 
   val identifier = "delinearize"
 

--- a/cmta/src/test/scala/cmt/DuplicateInsertBeforeArguments.scala
+++ b/cmta/src/test/scala/cmt/DuplicateInsertBeforeArguments.scala
@@ -1,17 +1,20 @@
 package cmt
 
-import org.scalatest.prop.Tables
-import scopt.OEffect.ReportError
-import sbt.io.syntax.{File, file}
 import cmt.TestDirectories.*
+import cmt.support.CommandLineArguments
+import org.scalatest.prop.Tables
+import sbt.io.syntax.{File, file}
+import scopt.OEffect.ReportError
 
-object DuplicateInsertBeforeArguments extends CommandLineArguments with Tables {
+object DuplicateInsertBeforeArguments extends CommandLineArguments[CmtaOptions] with Tables {
 
   val identifier = "dib"
 
   def invalidArguments(tempDirectory: File) = Table(
     ("args", "errors"),
-    (Seq(identifier), Seq(ReportError("Missing argument <Main repo>"), ReportError("Missing option --exercise-number"))),
+    (
+      Seq(identifier),
+      Seq(ReportError("Missing argument <Main repo>"), ReportError("Missing option --exercise-number"))),
     (
       Seq(identifier, nonExistentDirectory(tempDirectory)),
       Seq(

--- a/cmta/src/test/scala/cmt/LinearizeArguments.scala
+++ b/cmta/src/test/scala/cmt/LinearizeArguments.scala
@@ -1,6 +1,7 @@
 package cmt
 
 import cmt.TestDirectories.{firstRealDirectory, nonExistentDirectory, realFile, secondRealDirectory}
+import cmt.support.CommandLineArguments
 import org.scalatest.BeforeAndAfterAll
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.prop.Tables
@@ -9,7 +10,7 @@ import sbt.io.IO
 import sbt.io.syntax.{File, file}
 import scopt.OEffect.ReportError
 
-object LinearizeArguments extends CommandLineArguments with Tables {
+object LinearizeArguments extends CommandLineArguments[CmtaOptions] with Tables {
 
   val identifier = "linearize"
 
@@ -47,14 +48,10 @@ object LinearizeArguments extends CommandLineArguments with Tables {
       Seq(identifier, firstRealDirectory, secondRealDirectory, "--force-delete"),
       CmtaOptions(
         file(".").getAbsoluteFile.getParentFile,
-        Linearize(
-          linearizeBaseFolder = Some(file(secondRealDirectory)),
-          forceDeleteExistingDestinationFolder = true))),
+        Linearize(linearizeBaseFolder = Some(file(secondRealDirectory)), forceDeleteExistingDestinationFolder = true))),
     (
       Seq(identifier, firstRealDirectory, secondRealDirectory, "-f"),
       CmtaOptions(
         file(".").getAbsoluteFile.getParentFile,
-        Linearize(
-          linearizeBaseFolder = Some(file(secondRealDirectory)),
-          forceDeleteExistingDestinationFolder = true))))
+        Linearize(linearizeBaseFolder = Some(file(secondRealDirectory)), forceDeleteExistingDestinationFolder = true))))
 }

--- a/cmta/src/test/scala/cmt/RenumberArguments.scala
+++ b/cmta/src/test/scala/cmt/RenumberArguments.scala
@@ -1,11 +1,12 @@
 package cmt
 
 import cmt.TestDirectories.{firstRealDirectory, nonExistentDirectory, realFile, secondRealDirectory}
+import cmt.support.CommandLineArguments
 import org.scalatest.prop.Tables
 import sbt.io.syntax.{File, file}
 import scopt.OEffect.ReportError
 
-object RenumberArguments extends CommandLineArguments with Tables {
+object RenumberArguments extends CommandLineArguments[CmtaOptions] with Tables {
 
   val identifier = "renum"
 

--- a/cmta/src/test/scala/cmt/StudentifyArguments.scala
+++ b/cmta/src/test/scala/cmt/StudentifyArguments.scala
@@ -1,6 +1,7 @@
 package cmt
 
 import cmt.TestDirectories.*
+import cmt.support.CommandLineArguments
 import org.scalatest.BeforeAndAfterAll
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.prop.Tables
@@ -9,7 +10,7 @@ import sbt.io.IO
 import sbt.io.syntax.{File, file}
 import scopt.OEffect.ReportError
 
-object StudentifyArguments extends CommandLineArguments with Tables {
+object StudentifyArguments extends CommandLineArguments[CmtaOptions] with Tables {
 
   val identifier = "studentify"
 

--- a/cmtc/src/main/scala/cmt/CMTmain.scala
+++ b/cmtc/src/main/scala/cmt/CMTmain.scala
@@ -1,12 +1,14 @@
 package cmt
 
+import scopt.OEffect.ReportError
+
 object Main:
   def main(args: Array[String]): Unit =
-    val cmdLineArgs: CmtcOptions =
-      CmdLineParse.parse(args).getOrElse {
-        System.exit(1)
-        ???
-      }
+    CmdLineParse.parse(args) match
+      case Right(options)             => selectAndExecuteCommand(options)
+      case Left(CmdLineParseError(x)) => printError(x.collect { case ReportError(msg) => msg }.mkString("\n"))
+
+  private def selectAndExecuteCommand(cmdLineArgs: CmtcOptions): Unit = {
 
     val config: CMTcConfig =
       new CMTcConfig(cmdLineArgs.studentifiedRepo.get) // Safe: at this point we know that studentifiedRepo exists
@@ -43,3 +45,4 @@ object Main:
         CMTStudent.pullTemplate(studentifiedRepo, templatePath)(config)
       case _ =>
     }
+  }

--- a/cmtc/src/main/scala/cmt/CmdLineParse.scala
+++ b/cmtc/src/main/scala/cmt/CmdLineParse.scala
@@ -1,8 +1,8 @@
 package cmt
 
-import scopt.OParser
+import scopt.{OParser, OEffect}
 
-object CmdLineParse:
+object CmdLineParse extends CliParser:
 
-  def parse(args: Array[String]): Option[CmtcOptions] =
-    OParser.parse(parser, args, CmtcOptions())
+  def parse(args: Array[String]): Either[CmdLineParseError, CmtcOptions] =
+    _parse(parser, CmtcOptions())(args)

--- a/cmtc/src/test/scala/cmt/CommandLineParseTest.scala
+++ b/cmtc/src/test/scala/cmt/CommandLineParseTest.scala
@@ -1,0 +1,5 @@
+package cmt
+
+import cmt.support.CommandLineParseTestBase
+
+class CommandLineParseTest extends CommandLineParseTestBase[CmtcOptions](CmdLineParse.parse)

--- a/core/src/main/scala/cmt/CliParser.scala
+++ b/core/src/main/scala/cmt/CliParser.scala
@@ -1,0 +1,19 @@
+package cmt
+
+import scopt.{OEffect, OParser}
+
+final case class CmdLineParseError(errors: List[OEffect])
+
+trait CliParser {
+
+  protected def _parse[T](parser: OParser[_, T], options: T)(args: Array[String]): Either[CmdLineParseError, T] =
+    OParser.runParser(parser, args, options) match {
+      case (result, effects) => handleParsingResult(result, effects)
+    }
+
+  private def handleParsingResult[T](maybeResult: Option[T], effects: List[OEffect]): Either[CmdLineParseError, T] =
+    maybeResult match {
+      case Some(validOptions) => Right(validOptions)
+      case _                  => Left(CmdLineParseError(effects))
+    }
+}

--- a/core/src/test/scala/cmt/support/CommandLineParseTestBase.scala
+++ b/core/src/test/scala/cmt/support/CommandLineParseTestBase.scala
@@ -1,0 +1,72 @@
+package cmt.support
+
+import cmt.support.EitherSupport
+import cmt.{CliParser, CmdLineParseError}
+import org.scalatest.BeforeAndAfterAll
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.prop.TableFor2
+import org.scalatest.wordspec.AnyWordSpecLike
+import org.scalatestplus.scalacheck.ScalaCheckPropertyChecks
+import sbt.io.IO
+import sbt.io.syntax.*
+import scopt.OEffect.ReportError
+
+import scala.language.postfixOps
+
+trait CommandLineArguments[T] {
+  val identifier: String
+  def invalidArguments(tempDirectory: File): TableFor2[Seq[String], Seq[ReportError]]
+  def validArguments(tempDirectory: File): TableFor2[Seq[String], T]
+}
+
+abstract class CommandLineParseTestBase[T](
+    parseFn: Array[String] => Either[CmdLineParseError, T],
+    commandArguments: CommandLineArguments[T]*)
+    extends AnyWordSpecLike
+    with Matchers
+    with BeforeAndAfterAll
+    with ScalaCheckPropertyChecks
+    with EitherSupport {
+
+  private val tempDirectory = IO.createTemporaryDirectory
+
+  override def afterAll(): Unit =
+    tempDirectory.delete()
+
+  "CLI Parser" when {
+
+    commandArguments.foreach { command =>
+      s"given invalid ${command.identifier} arguments" should {
+
+        "report appropriate errors" in {
+          forAll(command.invalidArguments(tempDirectory)) { (args: Seq[String], errors: Seq[ReportError]) =>
+            assertFailureWithErrors(args.toArray, errors*)
+          }
+        }
+      }
+    }
+
+    commandArguments.foreach { command =>
+      s"given valid ${command.identifier} arguments" should {
+
+        "return expected results" in {
+          forAll(command.validArguments(tempDirectory)) { (args: Seq[String], expectedResult: T) =>
+            assertSuccessWithResponse(args.toArray, expectedResult)
+          }
+        }
+      }
+    }
+  }
+
+  private def assertFailureWithErrors(args: Array[String], errors: ReportError*) = {
+    val resultOr = parseFn(args)
+    val error = assertLeft(resultOr)
+    (error.errors should contain).allElementsOf(errors)
+  }
+
+  private def assertSuccessWithResponse(args: Array[String], expectedResult: T) = {
+    val resultOr = parseFn(args)
+    val result = assertRight(resultOr)
+    result shouldBe expectedResult
+  }
+}

--- a/core/src/test/scala/cmt/support/EitherSupport.scala
+++ b/core/src/test/scala/cmt/support/EitherSupport.scala
@@ -1,0 +1,18 @@
+package cmt.support
+
+import scopt.OEffect.ReportError
+
+trait EitherSupport {
+
+  def assertRight[E, T](either: Either[E, T]): T =
+    either match {
+      case Left(error)   => throw new IllegalStateException(s"Expected Either.right, got Either.left [$error]")
+      case Right(result) => result
+    }
+
+  def assertLeft[E, T](either: Either[E, T]): E =
+    either match {
+      case Left(error)   => error
+      case Right(result) => throw new IllegalStateException(s"Expected Either.left, got Either.right [$result]")
+    }
+}


### PR DESCRIPTION
I've abstracted the CLI testing operation to allow it to be used by both client and admin cli operations.

This required some abstraction of the CLI parsing itself which, it turns out, is pretty nicely abstractable... you just need to provide an `OParser[_, T]` and an object of type `T` that will be returned by the parser and everything else stays the same.

I'll add the actual tests for the client commands in the next PR.