### PR TITLE
Added version support

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,11 +1,23 @@
+import CommonSettings._
+
 lazy val `course-management-tools` =
   (project in file("."))
     .aggregate(cmta, cmtc, core)
-    .settings(CommonSettings.commonSettings: _*)
+    .settings(commonSettings: _*)
     .settings(publish / skip := true)
 
-lazy val core = project.in(file("core")).settings(CommonSettings.commonSettings: _*)
+lazy val core = project.in(file("core")).settings(commonSettings: _*)
 
-lazy val cmta = project.in(file("cmta")).dependsOn(core, core % "test->test").settings(CommonSettings.commonSettings: _*)
+lazy val cmta = project
+  .in(file("cmta"))
+  .enablePlugins(BuildInfoPlugin)
+  .dependsOn(core, core % "test->test")
+  .settings(commonSettings: _*)
+  .settings(buildInfoKeys := buildKeysWithName("Course Management Tools (Admin)"))
 
-lazy val cmtc = project.in(file("cmtc")).dependsOn(core, core % "test->test").settings(CommonSettings.commonSettings: _*)
+lazy val cmtc = project
+  .in(file("cmtc"))
+  .enablePlugins(BuildInfoPlugin)
+  .dependsOn(core, core % "test->test")
+  .settings(commonSettings: _*)
+  .settings(buildInfoKeys := buildKeysWithName("Course Management Tools (Client)"))

--- a/cmta/src/main/scala/cmt/CMTAdmin.scala
+++ b/cmta/src/main/scala/cmt/CMTAdmin.scala
@@ -2,8 +2,8 @@ package cmt
 
 import sbt.io.syntax.*
 import sbt.io.IO as sbtio
+import Helpers.{ExercisePrefixesAndExerciseNames, extractExerciseNr, getExercisePrefixAndExercises, validatePrefixes}
 
-import Helpers.{ExercisePrefixesAndExerciseNames, getExercisePrefixAndExercises, validatePrefixes, extractExerciseNr}
 object CMTAdmin:
   def renumberExercises(mainRepo: File, renumStartAtOpt: Option[Int], renumOffset: Int, renumStep: Int)(
       config: CMTaConfig): Either[String, Unit] =

--- a/cmta/src/main/scala/cmt/CMTmain.scala
+++ b/cmta/src/main/scala/cmt/CMTmain.scala
@@ -1,5 +1,6 @@
 package cmt
 
+import cmt.version.BuildInfo
 import scopt.OEffect.{ReportError, DisplayToErr}
 
 object Main:
@@ -46,6 +47,9 @@ object Main:
 
       case CmtaOptions(mainRepo, DeLinearize(Some(linBase)), _) =>
         CMTDeLinearize.delinearize(mainRepo, linBase)(config)
+
+      case CmtaOptions(_, Version, _) =>
+        printMessage(BuildInfo.toString)
 
       case _ =>
     }

--- a/cmta/src/main/scala/cmt/CmtaOptions.scala
+++ b/cmta/src/main/scala/cmt/CmtaOptions.scala
@@ -6,6 +6,7 @@ import sbt.io.syntax.*
 
 sealed trait CmtaCommands
 case object Missing extends CmtaCommands
+case object Version extends CmtaCommands
 final case class RenumberExercises(startRenumAt: Option[Int] = None, renumOffset: Int = 1, renumStep: Int = 1)
     extends CmtaCommands
 final case class DuplicateInsertBefore(exerciseNumber: Int = 0) extends CmtaCommands
@@ -37,6 +38,7 @@ val cmtaParser = {
     linearizeCmdParser,
     delinearizeCmdParser,
     configFileParser,
+    versionParser,
     validateConfig)
 }
 
@@ -192,6 +194,12 @@ private def renumCmdParser(using builder: OParserBuilder[CmtaOptions]): OParser[
         .throwOrAction { case (step, c @ CmtaOptions(_, RenumberExercises(startAt, offset, _), _)) =>
           c.copy(command = RenumberExercises(startAt, offset, step))
         })
+
+private def versionParser(using builder: OParserBuilder[CmtaOptions]): OParser[Unit, CmtaOptions] =
+  import builder.*
+  cmd("version").text("Print version information").action { (_, c) =>
+    c.copy(command = Version)
+  }
 
 extension [T](parser: OParser[T, CmtaOptions])
   def throwOrAction(pf: PartialFunction[(T, CmtaOptions), CmtaOptions]): OParser[T, CmtaOptions] =

--- a/cmta/src/test/scala/cmt/CommandLineParseTest.scala
+++ b/cmta/src/test/scala/cmt/CommandLineParseTest.scala
@@ -9,4 +9,5 @@ class CommandLineParseTest
       DuplicateInsertBeforeArguments,
       LinearizeArguments,
       DelinearizeArguments,
-      RenumberArguments)
+      RenumberArguments,
+      VersionArguments)

--- a/cmta/src/test/scala/cmt/VersionArguments.scala
+++ b/cmta/src/test/scala/cmt/VersionArguments.scala
@@ -1,0 +1,16 @@
+package cmt
+
+import cmt.TestDirectories.*
+import cmt.support.CommandLineArguments
+import org.scalatest.prop.Tables
+import sbt.io.syntax.{File, file}
+
+object VersionArguments extends CommandLineArguments[CmtaOptions] with Tables {
+
+  val identifier = "version"
+
+  def invalidArguments(tempDirectory: File) = Table(("args", "expectedErrors"))
+
+  def validArguments(tempDirectory: File) =
+    Table(("args", "expectedResult"), (Seq(identifier), CmtaOptions(file("."), Version)))
+}

--- a/cmtc/src/main/scala/cmt/CMTStudent.scala
+++ b/cmtc/src/main/scala/cmt/CMTStudent.scala
@@ -10,8 +10,10 @@ import sbt.io.syntax.*
 import sbt.io.{IO as sbtio}
 
 import Helpers.*
+import cmt.version.BuildInfo
 
 object CMTStudent:
+
   def moveToNextExercise(studentifiedRepo: File)(config: CMTcConfig): Unit =
 
     val currentExercise =

--- a/cmtc/src/main/scala/cmt/CMTStudent.scala
+++ b/cmtc/src/main/scala/cmt/CMTStudent.scala
@@ -1,16 +1,13 @@
 package cmt
 
+import cmt.Helpers.*
+import cmt.version.BuildInfo
 import com.typesafe.config.ConfigFactory
-
-import scala.jdk.CollectionConverters.*
+import sbt.io.IO as sbtio
+import sbt.io.syntax.*
 
 import java.nio.charset.StandardCharsets
-
-import sbt.io.syntax.*
-import sbt.io.{IO as sbtio}
-
-import Helpers.*
-import cmt.version.BuildInfo
+import scala.jdk.CollectionConverters.*
 
 object CMTStudent:
 

--- a/cmtc/src/main/scala/cmt/CMTmain.scala
+++ b/cmtc/src/main/scala/cmt/CMTmain.scala
@@ -1,5 +1,6 @@
 package cmt
 
+import cmt.version.BuildInfo
 import scopt.OEffect.ReportError
 
 object Main:
@@ -43,6 +44,10 @@ object Main:
 
       case CmtcOptions(PullTemplate(Some(templatePath)), Some(studentifiedRepo)) =>
         CMTStudent.pullTemplate(studentifiedRepo, templatePath)(config)
+
+      case CmtcOptions(Version, _) =>
+        printMessage(BuildInfo.toString)
+
       case _ =>
     }
   }

--- a/cmtc/src/main/scala/cmt/CmdOptions.scala
+++ b/cmtc/src/main/scala/cmt/CmdOptions.scala
@@ -7,6 +7,7 @@ import sbt.io.syntax.*
 
 sealed trait CmtcCommands
 case object Missing extends CmtcCommands
+case object Version extends CmtcCommands
 case object PullSolution extends CmtcCommands
 final case class RestoreState(exerciseID: Option[String] = None) extends CmtcCommands
 case object ListExercises extends CmtcCommands
@@ -36,6 +37,7 @@ val parser = {
     saveStateParser,
     restoreStateParser,
     savedStateParser,
+    versionParser,
     validateConfig)
 }
 
@@ -207,6 +209,12 @@ private def restoreStateParser(using builder: OParserBuilder[CmtcOptions]): OPar
           c.copy(studentifiedRepo = Some(repo))
         })
 
+private def versionParser(using builder: OParserBuilder[CmtcOptions]): OParser[Unit, CmtcOptions] =
+  import builder.*
+  cmd("version").text("Print version information").action { (_, c) =>
+    c.copy(command = Version)
+  }
+
 private def validateConfig(using builder: OParserBuilder[CmtcOptions]): OParser[Unit, CmtcOptions] =
   import builder.*
   checkConfig(config =>
@@ -222,4 +230,5 @@ private def validateConfig(using builder: OParserBuilder[CmtcOptions]): OParser[
       case _: GotoExercise   => success
       case GotoFirstExercise => success
       case _: PullTemplate   => success
+      case Version           => success
   )

--- a/cmtc/src/test/scala/cmt/CommandLineParseTest.scala
+++ b/cmtc/src/test/scala/cmt/CommandLineParseTest.scala
@@ -2,4 +2,4 @@ package cmt
 
 import cmt.support.CommandLineParseTestBase
 
-class CommandLineParseTest extends CommandLineParseTestBase[CmtcOptions](CmdLineParse.parse)
+class CommandLineParseTest extends CommandLineParseTestBase[CmtcOptions](CmdLineParse.parse, VersionArguments)

--- a/cmtc/src/test/scala/cmt/VersionArguments.scala
+++ b/cmtc/src/test/scala/cmt/VersionArguments.scala
@@ -1,0 +1,15 @@
+package cmt
+
+import cmt.support.CommandLineArguments
+import org.scalatest.prop.Tables
+import sbt.io.syntax.{File, file}
+
+object VersionArguments extends CommandLineArguments[CmtcOptions] with Tables {
+
+  val identifier = "version"
+
+  def invalidArguments(tempDirectory: File) = Table(("args", "expectedErrors"))
+
+  def validArguments(tempDirectory: File) =
+    Table(("args", "expectedResult"), (Seq(identifier), CmtcOptions(command = Version)))
+}

--- a/project/CommonSettings.scala
+++ b/project/CommonSettings.scala
@@ -1,5 +1,7 @@
 import sbt._
-import sbt.Keys._
+import sbt.Keys.{name, _}
+import sbtbuildinfo.BuildInfoKey
+import sbtbuildinfo.BuildInfoKeys._
 
 object CompileOptions {
   val compileOptions = Seq("-source:future")
@@ -11,8 +13,16 @@ object CommonSettings {
     version := "2.0.0-SNAPSHOT",
     scalaVersion := Version.scalaVersion,
     scalacOptions ++= CompileOptions.compileOptions,
+    buildInfoPackage := "cmt.version",
     Test / parallelExecution := false,
     Test / logBuffered := false,
     // ThisBuild / parallelExecution := false,
     libraryDependencies ++= Dependencies.cmtDependencies)
+
+  lazy val commonBuildInfoKeys = Seq[BuildInfoKey](version, scalaVersion, sbtVersion)
+
+  def buildKeysWithName(projectName: String): Seq[BuildInfoKey] =
+    BuildInfoKey.map(name) { case (k, _) =>
+      k -> projectName
+    } +: CommonSettings.commonBuildInfoKeys
 }

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,3 +1,3 @@
-//addSbtPlugin("com.eed3si9n" % "sbt-buildinfo" % "0.10.0")
+addSbtPlugin("com.eed3si9n" % "sbt-buildinfo" % "0.11.0")
 addSbtPlugin("org.scalameta" % "sbt-mdoc" % "2.2.3")
 addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.4.2")


### PR DESCRIPTION
Fix for eloots/course-management-tools#167 *Versioning*

- Added `sbt-buildinfo` plugin
- Added `BuildInfo` configuration (with customised name for client and admin tools)
- Added `version` command support for `cmtc` and `cmta`
- Tests for the `version` commands in both `cmtc` and `cmta`