### PR TITLE
Fix failing tests on Windows (10)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,6 +57,45 @@ jobs:
           cd CMT &&
           sbt test
 
+  run-tests-windows:
+    runs-on: windows-latest
+
+    steps:
+
+      - name: Checkout Course Management Tools Repo
+        uses: actions/checkout@v2
+        with:
+          path: CMT
+          fetch-depth: 0
+
+      - name: Set up JDK 11
+        uses: actions/setup-java@v1
+        with:
+          java-version: 11
+
+      - name: Cache Ivy
+        uses: actions/cache@v2
+        with:
+          path: ~/.ivy2/cache
+          key: ${{ runner.os }}-ivy--${{ hashFiles('**/build.sbt') }}
+          restore-keys: |
+            ${{ runner.os }}-ivy-
+            ${{ runner.os }}-
+
+      - name: Cache SBT
+        uses: actions/cache@v2
+        with:
+          path: ~/.sbt
+          key: ${{ runner.os }}-sbt-${{ hashFiles('project/**') }}
+          restore-keys: |
+            ${{ runner.os }}-sbt-
+            ${{ runner.os }}-
+
+      - name: Run tests
+        run: |
+          cd CMT &&
+          sbt test
+
   create-release:
     runs-on: ubuntu-latest
     needs: [run-tests]

--- a/cmta/src/test/scala/cmt/admin/cli/DelinearizeArguments.scala
+++ b/cmta/src/test/scala/cmt/admin/cli/DelinearizeArguments.scala
@@ -47,6 +47,6 @@ object DelinearizeArguments extends CommandLineArguments[CliOptions] with Tables
       Seq(identifier, firstRealDirectory, secondRealDirectory),
       CliOptions.default(
         command = DeLinearize,
-        mainRepository = MainRepository(Helpers.resolveMainRepoPath(file(".")).toOption.getOrElse(file("."))),
+        mainRepository = MainRepository(baseDirectoryGitRoot),
         maybeLinearizeBaseFolder = Some(LinearizeBaseDirectory(file(secondRealDirectory))))))
 }

--- a/cmta/src/test/scala/cmt/admin/cli/DelinearizeArguments.scala
+++ b/cmta/src/test/scala/cmt/admin/cli/DelinearizeArguments.scala
@@ -13,6 +13,7 @@ package cmt.admin.cli
   * See the License for the specific language governing permissions and limitations under the License.
   */
 
+import cmt.Helpers
 import cmt.admin.Domain.{LinearizeBaseDirectory, MainRepository}
 import cmt.admin.cli.CliCommand.DeLinearize
 import cmt.support.{CommandLineArguments, TestDirectories}
@@ -46,6 +47,6 @@ object DelinearizeArguments extends CommandLineArguments[CliOptions] with Tables
       Seq(identifier, firstRealDirectory, secondRealDirectory),
       CliOptions.default(
         command = DeLinearize,
-        mainRepository = MainRepository(file(".").getAbsoluteFile.getParentFile),
+        mainRepository = MainRepository(Helpers.resolveMainRepoPath(file(".")).toOption.getOrElse(file("."))),
         maybeLinearizeBaseFolder = Some(LinearizeBaseDirectory(file(secondRealDirectory))))))
 }

--- a/cmta/src/test/scala/cmt/admin/cli/DuplicateInsertBeforeArguments.scala
+++ b/cmta/src/test/scala/cmt/admin/cli/DuplicateInsertBeforeArguments.scala
@@ -13,8 +13,10 @@ package cmt.admin.cli
   * See the License for the specific language governing permissions and limitations under the License.
   */
 
-import cmt.admin.Domain.ExerciseNumber
+import cmt.Helpers
+import cmt.admin.Domain.{ExerciseNumber, MainRepository}
 import cmt.admin.cli.CliCommand.DuplicateInsertBefore
+import cmt.admin.cli.RenumberArguments.baseDirectory
 import cmt.support.{CommandLineArguments, TestDirectories}
 import org.scalatest.prop.Tables
 import sbt.io.syntax.File
@@ -45,5 +47,8 @@ object DuplicateInsertBeforeArguments extends CommandLineArguments[CliOptions] w
     ("args", "expectedResult"),
     (
       Seq(identifier, firstRealDirectory, "--exercise-number", "1"),
-      CliOptions.default(command = DuplicateInsertBefore, exerciseNumber = ExerciseNumber(1))))
+      CliOptions.default(
+        command = DuplicateInsertBefore,
+        mainRepository = MainRepository(Helpers.resolveMainRepoPath(baseDirectory).toOption.getOrElse(baseDirectory)),
+        exerciseNumber = ExerciseNumber(1))))
 }

--- a/cmta/src/test/scala/cmt/admin/cli/DuplicateInsertBeforeArguments.scala
+++ b/cmta/src/test/scala/cmt/admin/cli/DuplicateInsertBeforeArguments.scala
@@ -16,7 +16,6 @@ package cmt.admin.cli
 import cmt.Helpers
 import cmt.admin.Domain.{ExerciseNumber, MainRepository}
 import cmt.admin.cli.CliCommand.DuplicateInsertBefore
-import cmt.admin.cli.RenumberArguments.baseDirectory
 import cmt.support.{CommandLineArguments, TestDirectories}
 import org.scalatest.prop.Tables
 import sbt.io.syntax.File
@@ -49,6 +48,6 @@ object DuplicateInsertBeforeArguments extends CommandLineArguments[CliOptions] w
       Seq(identifier, firstRealDirectory, "--exercise-number", "1"),
       CliOptions.default(
         command = DuplicateInsertBefore,
-        mainRepository = MainRepository(Helpers.resolveMainRepoPath(baseDirectory).toOption.getOrElse(baseDirectory)),
+        mainRepository = MainRepository(baseDirectoryGitRoot),
         exerciseNumber = ExerciseNumber(1))))
 }

--- a/cmta/src/test/scala/cmt/admin/cli/LinearizeArguments.scala
+++ b/cmta/src/test/scala/cmt/admin/cli/LinearizeArguments.scala
@@ -47,23 +47,20 @@ object LinearizeArguments extends CommandLineArguments[CliOptions] with Tables w
       Seq(identifier, firstRealDirectory, secondRealDirectory),
       CliOptions.default(
         command = Linearize,
-        mainRepository =
-          MainRepository(Helpers.resolveMainRepoPath(currentDirectory).toOption.getOrElse(currentDirectory)),
+        mainRepository = MainRepository(baseDirectoryGitRoot),
         maybeLinearizeBaseFolder = Some(LinearizeBaseDirectory(file(secondRealDirectory))))),
     (
       Seq(identifier, firstRealDirectory, secondRealDirectory, "--force-delete"),
       CliOptions.default(
         command = Linearize,
-        mainRepository =
-          MainRepository(Helpers.resolveMainRepoPath(currentDirectory).toOption.getOrElse(currentDirectory)),
+        mainRepository = MainRepository(baseDirectoryGitRoot),
         maybeLinearizeBaseFolder = Some(LinearizeBaseDirectory(file(secondRealDirectory))),
         forceDeleteDestinationDirectory = ForceDeleteDestinationDirectory(true))),
     (
       Seq(identifier, firstRealDirectory, secondRealDirectory, "-f"),
       CliOptions.default(
         command = Linearize,
-        mainRepository =
-          MainRepository(Helpers.resolveMainRepoPath(currentDirectory).toOption.getOrElse(currentDirectory)),
+        mainRepository = MainRepository(baseDirectoryGitRoot),
         maybeLinearizeBaseFolder = Some(LinearizeBaseDirectory(file(secondRealDirectory))),
         forceDeleteDestinationDirectory = ForceDeleteDestinationDirectory(true))))
 }

--- a/cmta/src/test/scala/cmt/admin/cli/LinearizeArguments.scala
+++ b/cmta/src/test/scala/cmt/admin/cli/LinearizeArguments.scala
@@ -13,6 +13,7 @@ package cmt.admin.cli
   * See the License for the specific language governing permissions and limitations under the License.
   */
 
+import cmt.Helpers
 import cmt.admin.Domain.{ForceDeleteDestinationDirectory, LinearizeBaseDirectory, MainRepository}
 import cmt.admin.cli.CliCommand.Linearize
 import cmt.support.{CommandLineArguments, TestDirectories}
@@ -46,20 +47,23 @@ object LinearizeArguments extends CommandLineArguments[CliOptions] with Tables w
       Seq(identifier, firstRealDirectory, secondRealDirectory),
       CliOptions.default(
         command = Linearize,
-        mainRepository = MainRepository(currentDirectory),
+        mainRepository =
+          MainRepository(Helpers.resolveMainRepoPath(currentDirectory).toOption.getOrElse(currentDirectory)),
         maybeLinearizeBaseFolder = Some(LinearizeBaseDirectory(file(secondRealDirectory))))),
     (
       Seq(identifier, firstRealDirectory, secondRealDirectory, "--force-delete"),
       CliOptions.default(
         command = Linearize,
-        mainRepository = MainRepository(currentDirectory),
+        mainRepository =
+          MainRepository(Helpers.resolveMainRepoPath(currentDirectory).toOption.getOrElse(currentDirectory)),
         maybeLinearizeBaseFolder = Some(LinearizeBaseDirectory(file(secondRealDirectory))),
         forceDeleteDestinationDirectory = ForceDeleteDestinationDirectory(true))),
     (
       Seq(identifier, firstRealDirectory, secondRealDirectory, "-f"),
       CliOptions.default(
         command = Linearize,
-        mainRepository = MainRepository(currentDirectory),
+        mainRepository =
+          MainRepository(Helpers.resolveMainRepoPath(currentDirectory).toOption.getOrElse(currentDirectory)),
         maybeLinearizeBaseFolder = Some(LinearizeBaseDirectory(file(secondRealDirectory))),
         forceDeleteDestinationDirectory = ForceDeleteDestinationDirectory(true))))
 }

--- a/cmta/src/test/scala/cmt/admin/cli/RenumberArguments.scala
+++ b/cmta/src/test/scala/cmt/admin/cli/RenumberArguments.scala
@@ -16,7 +16,6 @@ package cmt.admin.cli
 import cmt.Helpers
 import cmt.admin.Domain.{MainRepository, RenumberOffset, RenumberStart, RenumberStep}
 import cmt.admin.cli.CliCommand.RenumberExercises
-import cmt.admin.cli.StudentifyArguments.baseDirectory
 import cmt.support.{CommandLineArguments, TestDirectories}
 import cmt.support.CommandLineArguments.{invalidArgumentsTable, validArgumentsTable}
 import org.scalatest.prop.Tables
@@ -40,32 +39,30 @@ object RenumberArguments extends CommandLineArguments[CliOptions] with Tables wi
   def validArguments(tempDirectory: File) = validArgumentsTable(
     (
       Seq(identifier, firstRealDirectory),
-      CliOptions.default(
-        command = RenumberExercises,
-        mainRepository = MainRepository(Helpers.resolveMainRepoPath(baseDirectory).toOption.getOrElse(baseDirectory)))),
+      CliOptions.default(command = RenumberExercises, mainRepository = MainRepository(baseDirectoryGitRoot))),
     (
       Seq(identifier, firstRealDirectory, "--from", "9"),
       CliOptions.default(
         command = RenumberExercises,
-        mainRepository = MainRepository(Helpers.resolveMainRepoPath(baseDirectory).toOption.getOrElse(baseDirectory)),
+        mainRepository = MainRepository(baseDirectoryGitRoot),
         maybeRenumberStart = Some(RenumberStart(9)))),
     (
       Seq(identifier, firstRealDirectory, "--to", "99"),
       CliOptions.default(
         command = RenumberExercises,
-        mainRepository = MainRepository(Helpers.resolveMainRepoPath(baseDirectory).toOption.getOrElse(baseDirectory)),
+        mainRepository = MainRepository(baseDirectoryGitRoot),
         renumberOffset = RenumberOffset(99))),
     (
       Seq(identifier, firstRealDirectory, "--step", "999"),
       CliOptions.default(
         command = RenumberExercises,
-        mainRepository = MainRepository(Helpers.resolveMainRepoPath(baseDirectory).toOption.getOrElse(baseDirectory)),
+        mainRepository = MainRepository(baseDirectoryGitRoot),
         renumberStep = RenumberStep(999))),
     (
       Seq(identifier, firstRealDirectory, "--from", "1", "--to", "2", "--step", "3"),
       CliOptions.default(
         command = RenumberExercises,
-        mainRepository = MainRepository(Helpers.resolveMainRepoPath(baseDirectory).toOption.getOrElse(baseDirectory)),
+        mainRepository = MainRepository(baseDirectoryGitRoot),
         maybeRenumberStart = Some(RenumberStart(1)),
         renumberOffset = RenumberOffset(2),
         renumberStep = RenumberStep(3))))

--- a/cmta/src/test/scala/cmt/admin/cli/RenumberArguments.scala
+++ b/cmta/src/test/scala/cmt/admin/cli/RenumberArguments.scala
@@ -13,8 +13,10 @@ package cmt.admin.cli
   * See the License for the specific language governing permissions and limitations under the License.
   */
 
+import cmt.Helpers
 import cmt.admin.Domain.{MainRepository, RenumberOffset, RenumberStart, RenumberStep}
 import cmt.admin.cli.CliCommand.RenumberExercises
+import cmt.admin.cli.StudentifyArguments.baseDirectory
 import cmt.support.{CommandLineArguments, TestDirectories}
 import cmt.support.CommandLineArguments.{invalidArgumentsTable, validArgumentsTable}
 import org.scalatest.prop.Tables
@@ -40,30 +42,30 @@ object RenumberArguments extends CommandLineArguments[CliOptions] with Tables wi
       Seq(identifier, firstRealDirectory),
       CliOptions.default(
         command = RenumberExercises,
-        mainRepository = MainRepository(file(".").getAbsoluteFile.getParentFile))),
+        mainRepository = MainRepository(Helpers.resolveMainRepoPath(baseDirectory).toOption.getOrElse(baseDirectory)))),
     (
       Seq(identifier, firstRealDirectory, "--from", "9"),
       CliOptions.default(
         command = RenumberExercises,
-        mainRepository = MainRepository(currentDirectory),
+        mainRepository = MainRepository(Helpers.resolveMainRepoPath(baseDirectory).toOption.getOrElse(baseDirectory)),
         maybeRenumberStart = Some(RenumberStart(9)))),
     (
       Seq(identifier, firstRealDirectory, "--to", "99"),
       CliOptions.default(
         command = RenumberExercises,
-        mainRepository = MainRepository(currentDirectory),
+        mainRepository = MainRepository(Helpers.resolveMainRepoPath(baseDirectory).toOption.getOrElse(baseDirectory)),
         renumberOffset = RenumberOffset(99))),
     (
       Seq(identifier, firstRealDirectory, "--step", "999"),
       CliOptions.default(
         command = RenumberExercises,
-        mainRepository = MainRepository(currentDirectory),
+        mainRepository = MainRepository(Helpers.resolveMainRepoPath(baseDirectory).toOption.getOrElse(baseDirectory)),
         renumberStep = RenumberStep(999))),
     (
       Seq(identifier, firstRealDirectory, "--from", "1", "--to", "2", "--step", "3"),
       CliOptions.default(
         command = RenumberExercises,
-        mainRepository = MainRepository(currentDirectory),
+        mainRepository = MainRepository(Helpers.resolveMainRepoPath(baseDirectory).toOption.getOrElse(baseDirectory)),
         maybeRenumberStart = Some(RenumberStart(1)),
         renumberOffset = RenumberOffset(2),
         renumberStep = RenumberStep(3))))

--- a/cmta/src/test/scala/cmt/admin/cli/StudentifyArguments.scala
+++ b/cmta/src/test/scala/cmt/admin/cli/StudentifyArguments.scala
@@ -16,7 +16,6 @@ package cmt.admin.cli
 import cmt.Helpers
 import cmt.admin.Domain.{ForceDeleteDestinationDirectory, InitializeGitRepo, MainRepository, StudentifyBaseDirectory}
 import cmt.admin.cli.CliCommand.Studentify
-import cmt.admin.cli.LinearizeArguments.currentDirectory
 import cmt.support.{CommandLineArguments, TestDirectories}
 import cmt.support.CommandLineArguments.{invalidArgumentsTable, validArgumentsTable}
 import org.scalatest.prop.Tables
@@ -52,41 +51,41 @@ object StudentifyArguments extends CommandLineArguments[CliOptions] with Tables 
       Seq(identifier, firstRealDirectory, secondRealDirectory),
       CliOptions.default(
         command = Studentify,
-        mainRepository = MainRepository(Helpers.resolveMainRepoPath(baseDirectory).toOption.getOrElse(baseDirectory)),
+        mainRepository = MainRepository(baseDirectoryGitRoot),
         maybeStudentifyBaseFolder = Some(StudentifyBaseDirectory(file(secondRealDirectory))))),
     (
       Seq(identifier, firstRealDirectory, secondRealDirectory, "--force-delete"),
       CliOptions.default(
         command = Studentify,
-        mainRepository = MainRepository(Helpers.resolveMainRepoPath(baseDirectory).toOption.getOrElse(baseDirectory)),
+        mainRepository = MainRepository(baseDirectoryGitRoot),
         maybeStudentifyBaseFolder = Some(StudentifyBaseDirectory(file(secondRealDirectory))),
         forceDeleteDestinationDirectory = ForceDeleteDestinationDirectory(true))),
     (
       Seq(identifier, firstRealDirectory, secondRealDirectory, "-f"),
       CliOptions.default(
         command = Studentify,
-        mainRepository = MainRepository(Helpers.resolveMainRepoPath(baseDirectory).toOption.getOrElse(baseDirectory)),
+        mainRepository = MainRepository(baseDirectoryGitRoot),
         maybeStudentifyBaseFolder = Some(StudentifyBaseDirectory(file(secondRealDirectory))),
         forceDeleteDestinationDirectory = ForceDeleteDestinationDirectory(true))),
     (
       Seq(identifier, firstRealDirectory, secondRealDirectory, "--init-git"),
       CliOptions.default(
         command = Studentify,
-        mainRepository = MainRepository(Helpers.resolveMainRepoPath(baseDirectory).toOption.getOrElse(baseDirectory)),
+        mainRepository = MainRepository(baseDirectoryGitRoot),
         maybeStudentifyBaseFolder = Some(StudentifyBaseDirectory(file(secondRealDirectory))),
         initializeAsGitRepo = InitializeGitRepo(true))),
     (
       Seq(identifier, firstRealDirectory, secondRealDirectory, "-g"),
       CliOptions.default(
         command = Studentify,
-        mainRepository = MainRepository(Helpers.resolveMainRepoPath(baseDirectory).toOption.getOrElse(baseDirectory)),
+        mainRepository = MainRepository(baseDirectoryGitRoot),
         maybeStudentifyBaseFolder = Some(StudentifyBaseDirectory(file(secondRealDirectory))),
         initializeAsGitRepo = InitializeGitRepo(true))),
     (
       Seq(identifier, firstRealDirectory, secondRealDirectory, "--force-delete", "--init-git"),
       CliOptions.default(
         command = Studentify,
-        mainRepository = MainRepository(Helpers.resolveMainRepoPath(baseDirectory).toOption.getOrElse(baseDirectory)),
+        mainRepository = MainRepository(baseDirectoryGitRoot),
         maybeStudentifyBaseFolder = Some(StudentifyBaseDirectory(file(secondRealDirectory))),
         forceDeleteDestinationDirectory = ForceDeleteDestinationDirectory(true),
         initializeAsGitRepo = InitializeGitRepo(true))),
@@ -94,7 +93,7 @@ object StudentifyArguments extends CommandLineArguments[CliOptions] with Tables 
       Seq(identifier, firstRealDirectory, secondRealDirectory, "-f", "-g"),
       CliOptions.default(
         command = Studentify,
-        mainRepository = MainRepository(Helpers.resolveMainRepoPath(baseDirectory).toOption.getOrElse(baseDirectory)),
+        mainRepository = MainRepository(baseDirectoryGitRoot),
         maybeStudentifyBaseFolder = Some(StudentifyBaseDirectory(file(secondRealDirectory))),
         forceDeleteDestinationDirectory = ForceDeleteDestinationDirectory(true),
         initializeAsGitRepo = InitializeGitRepo(true))))

--- a/cmta/src/test/scala/cmt/admin/cli/StudentifyArguments.scala
+++ b/cmta/src/test/scala/cmt/admin/cli/StudentifyArguments.scala
@@ -13,8 +13,10 @@ package cmt.admin.cli
   * See the License for the specific language governing permissions and limitations under the License.
   */
 
+import cmt.Helpers
 import cmt.admin.Domain.{ForceDeleteDestinationDirectory, InitializeGitRepo, MainRepository, StudentifyBaseDirectory}
 import cmt.admin.cli.CliCommand.Studentify
+import cmt.admin.cli.LinearizeArguments.currentDirectory
 import cmt.support.{CommandLineArguments, TestDirectories}
 import cmt.support.CommandLineArguments.{invalidArgumentsTable, validArgumentsTable}
 import org.scalatest.prop.Tables
@@ -50,41 +52,41 @@ object StudentifyArguments extends CommandLineArguments[CliOptions] with Tables 
       Seq(identifier, firstRealDirectory, secondRealDirectory),
       CliOptions.default(
         command = Studentify,
-        mainRepository = MainRepository(baseDirectory),
+        mainRepository = MainRepository(Helpers.resolveMainRepoPath(baseDirectory).toOption.getOrElse(baseDirectory)),
         maybeStudentifyBaseFolder = Some(StudentifyBaseDirectory(file(secondRealDirectory))))),
     (
       Seq(identifier, firstRealDirectory, secondRealDirectory, "--force-delete"),
       CliOptions.default(
         command = Studentify,
-        mainRepository = MainRepository(baseDirectory),
+        mainRepository = MainRepository(Helpers.resolveMainRepoPath(baseDirectory).toOption.getOrElse(baseDirectory)),
         maybeStudentifyBaseFolder = Some(StudentifyBaseDirectory(file(secondRealDirectory))),
         forceDeleteDestinationDirectory = ForceDeleteDestinationDirectory(true))),
     (
       Seq(identifier, firstRealDirectory, secondRealDirectory, "-f"),
       CliOptions.default(
         command = Studentify,
-        mainRepository = MainRepository(baseDirectory),
+        mainRepository = MainRepository(Helpers.resolveMainRepoPath(baseDirectory).toOption.getOrElse(baseDirectory)),
         maybeStudentifyBaseFolder = Some(StudentifyBaseDirectory(file(secondRealDirectory))),
         forceDeleteDestinationDirectory = ForceDeleteDestinationDirectory(true))),
     (
       Seq(identifier, firstRealDirectory, secondRealDirectory, "--init-git"),
       CliOptions.default(
         command = Studentify,
-        mainRepository = MainRepository(baseDirectory),
+        mainRepository = MainRepository(Helpers.resolveMainRepoPath(baseDirectory).toOption.getOrElse(baseDirectory)),
         maybeStudentifyBaseFolder = Some(StudentifyBaseDirectory(file(secondRealDirectory))),
         initializeAsGitRepo = InitializeGitRepo(true))),
     (
       Seq(identifier, firstRealDirectory, secondRealDirectory, "-g"),
       CliOptions.default(
         command = Studentify,
-        mainRepository = MainRepository(baseDirectory),
+        mainRepository = MainRepository(Helpers.resolveMainRepoPath(baseDirectory).toOption.getOrElse(baseDirectory)),
         maybeStudentifyBaseFolder = Some(StudentifyBaseDirectory(file(secondRealDirectory))),
         initializeAsGitRepo = InitializeGitRepo(true))),
     (
       Seq(identifier, firstRealDirectory, secondRealDirectory, "--force-delete", "--init-git"),
       CliOptions.default(
         command = Studentify,
-        mainRepository = MainRepository(baseDirectory),
+        mainRepository = MainRepository(Helpers.resolveMainRepoPath(baseDirectory).toOption.getOrElse(baseDirectory)),
         maybeStudentifyBaseFolder = Some(StudentifyBaseDirectory(file(secondRealDirectory))),
         forceDeleteDestinationDirectory = ForceDeleteDestinationDirectory(true),
         initializeAsGitRepo = InitializeGitRepo(true))),
@@ -92,7 +94,7 @@ object StudentifyArguments extends CommandLineArguments[CliOptions] with Tables 
       Seq(identifier, firstRealDirectory, secondRealDirectory, "-f", "-g"),
       CliOptions.default(
         command = Studentify,
-        mainRepository = MainRepository(baseDirectory),
+        mainRepository = MainRepository(Helpers.resolveMainRepoPath(baseDirectory).toOption.getOrElse(baseDirectory)),
         maybeStudentifyBaseFolder = Some(StudentifyBaseDirectory(file(secondRealDirectory))),
         forceDeleteDestinationDirectory = ForceDeleteDestinationDirectory(true),
         initializeAsGitRepo = InitializeGitRepo(true))))

--- a/core/src/main/scala/cmt/CMTcConfig.scala
+++ b/core/src/main/scala/cmt/CMTcConfig.scala
@@ -19,10 +19,9 @@ import com.typesafe.config.{Config, ConfigFactory}
 
 import scala.jdk.CollectionConverters.*
 import java.nio.charset.StandardCharsets
-import Helpers.*
 
 class CMTcConfig(studentifiedRepo: File):
-  private val separatorChar: Char = java.io.File.separatorChar
+  import Helpers.adaptToOSSeparatorChar
 
   val bookmarkFile: File = studentifiedRepo / ".bookmark"
 
@@ -32,15 +31,6 @@ class CMTcConfig(studentifiedRepo: File):
   val cmtSettings: Config = ConfigFactory.parseFile(cmtConfigFile)
 
   val exercises: collection.mutable.Seq[String] = cmtSettings.getStringList("exercises").asScala
-
-  private def adaptToOSSeparatorChar(path: String): String =
-    separatorChar match
-      case '\\' =>
-        path.replaceAll("/", """\\""")
-      case '/' =>
-        path
-      case _ =>
-        path.replaceAll(s"/", s"$separatorChar")
 
   val dontTouch: Set[String] =
     cmtSettings.getStringList("cmt-studentified-dont-touch").asScala.toSet.map(adaptToOSSeparatorChar)

--- a/core/src/test/scala/cmt/support/TestDirectories.scala
+++ b/core/src/test/scala/cmt/support/TestDirectories.scala
@@ -14,15 +14,17 @@ package cmt.support
   */
 
 import sbt.io.syntax.{File, file}
+import cmt.Helpers.adaptToOSSeparatorChar
 
 trait TestDirectories {
 
   def baseDirectory = file(".").getAbsoluteFile.getParentFile
 
-  def nonExistentDirectory(tempDirectory: File) = s"${tempDirectory.getAbsolutePath}/i/do/not/exist"
-  val firstRealDirectory = "./cmta/src/test/resources/i-am-a-directory"
-  val secondRealDirectory = "./cmta/src/test/resources/i-am-another-directory"
-  val realFile = "./cmta/src/test/resources/i-am-a-file.txt"
+  def nonExistentDirectory(tempDirectory: File) = adaptToOSSeparatorChar(
+    s"${tempDirectory.getAbsolutePath}/i/do/not/exist")
+  val firstRealDirectory = adaptToOSSeparatorChar("./cmta/src/test/resources/i-am-a-directory")
+  val secondRealDirectory = adaptToOSSeparatorChar("./cmta/src/test/resources/i-am-another-directory")
+  val realFile = adaptToOSSeparatorChar("./cmta/src/test/resources/i-am-a-file.txt")
 
   val currentDirectory = file(".").getAbsoluteFile.getParentFile
 }

--- a/core/src/test/scala/cmt/support/TestDirectories.scala
+++ b/core/src/test/scala/cmt/support/TestDirectories.scala
@@ -13,12 +13,14 @@ package cmt.support
   * See the License for the specific language governing permissions and limitations under the License.
   */
 
+import cmt.Helpers
 import sbt.io.syntax.{File, file}
 import cmt.Helpers.adaptToOSSeparatorChar
 
 trait TestDirectories {
 
   def baseDirectory = file(".").getAbsoluteFile.getParentFile
+  def baseDirectoryGitRoot = Helpers.resolveMainRepoPath(baseDirectory).toOption.getOrElse(baseDirectory)
 
   def nonExistentDirectory(tempDirectory: File) = adaptToOSSeparatorChar(
     s"${tempDirectory.getAbsolutePath}/i/do/not/exist")
@@ -26,5 +28,4 @@ trait TestDirectories {
   val secondRealDirectory = adaptToOSSeparatorChar("./cmta/src/test/resources/i-am-another-directory")
   val realFile = adaptToOSSeparatorChar("./cmta/src/test/resources/i-am-a-file.txt")
 
-  val currentDirectory = file(".").getAbsoluteFile.getParentFile
 }

--- a/functional-tests/src/test/scala/cmt/StudentificationFunctionalSpec.scala
+++ b/functional-tests/src/test/scala/cmt/StudentificationFunctionalSpec.scala
@@ -182,7 +182,8 @@ trait StudentifiedRepoFixture {
     import cmt.client.command.ClientCommand.PullTemplate
     import cmt.client.Domain.TemplatePath
     import cmt.client.command.execution.given
-    PullTemplate(config, StudentifiedRepo(studentifiedRepo), TemplatePath(templatePath)).execute()
+    PullTemplate(config, StudentifiedRepo(studentifiedRepo), TemplatePath(Helpers.adaptToOSSeparatorChar(templatePath)))
+      .execute()
 
   def addFileToStudentifiedRepo(studentifiedRepo: File, filePath: String): SourceFiles =
     val fileContent = UUID.randomUUID()
@@ -235,7 +236,9 @@ final class StudentificationFunctionalSpec
       When("a file is added to a folder that is marked as 'don't touch' in the main configuration")
 
       val dontTouchMeFile =
-        addFileToStudentifiedRepo(studentifiedRepoCodeFolder, ".mvn/someFolder/mustNotBeTouchedByCmt")
+        addFileToStudentifiedRepo(
+          studentifiedRepoCodeFolder,
+          Helpers.adaptToOSSeparatorChar(".mvn/someFolder/mustNotBeTouchedByCmt"))
 
       Then("We should see that file as part of the overall file set")
 
@@ -361,8 +364,12 @@ final class StudentificationFunctionalSpec
       When("the current state of an exercise is mutated and subsequently saved with the 'save-state' command")
 
       val modifiedMainCode =
-        addFileToStudentifiedRepo(studentifiedRepoCodeFolder, "src/main/cmt/Main.scala") ++
-          addFileToStudentifiedRepo(studentifiedRepoCodeFolder, "src/main/cmt/pack/Toto.scala")
+        addFileToStudentifiedRepo(
+          studentifiedRepoCodeFolder,
+          Helpers.adaptToOSSeparatorChar("src/main/cmt/Main.scala")) ++
+          addFileToStudentifiedRepo(
+            studentifiedRepoCodeFolder,
+            Helpers.adaptToOSSeparatorChar("src/main/cmt/pack/Toto.scala"))
 
       saveState(cMTcConfig, studentifiedRepoFolder)
 
@@ -403,7 +410,9 @@ final class StudentificationFunctionalSpec
       When("restoring the previously saved state using the 'restore-state' command")
 
       val dontTouchMeFile_1 =
-        addFileToStudentifiedRepo(studentifiedRepoCodeFolder, ".mvn/someFolder/mustNotBeTouchedByCmt")
+        addFileToStudentifiedRepo(
+          studentifiedRepoCodeFolder,
+          Helpers.adaptToOSSeparatorChar(".mvn/someFolder/mustNotBeTouchedByCmt"))
       restoreState(cMTcConfig, studentifiedRepoFolder, "exercise_001_desc")
 
       Then("should fully reflect what was saved")

--- a/functional-tests/src/test/scala/cmt/support/TestSupport.scala
+++ b/functional-tests/src/test/scala/cmt/support/TestSupport.scala
@@ -14,7 +14,7 @@ package cmt.support
   */
 
 import cmt.CMTaConfig
-import cmt.Helpers.{commitToGit, dumpStringToFile, initializeGitRepo, setGitConfig}
+import cmt.Helpers.{commitToGit, dumpStringToFile, initializeGitRepo, setGitConfig, adaptToOSSeparatorChar}
 import cmt.admin.Domain.MainRepository
 import cmt.admin.cli.CliCommand.Studentify
 import sbt.io.IO as sbtio
@@ -31,7 +31,7 @@ opaque type ExerciseMetadata = Map[ExerciseName, SourcesStruct]
 
 extension (sfs: SourceFileStruct)
   def toSourceFiles: SourceFiles =
-    sfs.map(n => (n, UUID.randomUUID())).to(Map)
+    sfs.map(n => (n, UUID.randomUUID())).to(Map).map { case (k, v) => (adaptToOSSeparatorChar(k), v) }
 
 object ExerciseMetadata:
   def apply(): ExerciseMetadata = Map.empty
@@ -74,12 +74,16 @@ object Exercises:
 
     def getMainCode(exerciseName: ExerciseName): SourceFiles =
       exercises(exerciseName).main
+
     def getMainFile(exerciseName: ExerciseName, filePath: String): Tuple2[FilePath, CheckSum] =
-      filePath -> getMainCode(exerciseName)(filePath)
+      adaptToOSSeparatorChar(filePath) -> getMainCode(exerciseName)(adaptToOSSeparatorChar(filePath))
+
     def getTestCode(exerciseName: ExerciseName): SourceFiles =
       exercises(exerciseName).test
+
     def getReadmeCode(exerciseName: ExerciseName): SourceFiles =
       exercises(exerciseName).readme
+
     def getAllCode(exerciseName: ExerciseName): SourceFiles =
       getMainCode(exerciseName) ++ getTestCode(exerciseName) ++ getReadmeCode(exerciseName)
 


### PR DESCRIPTION
Causes of failing tests
  - separator character '/' on *nix and '\' on windows
  - CMT main repo gets validated using git which causes the drive letter in a file path to change to a UNC